### PR TITLE
Force TLSv1 in Faraday connection

### DIFF
--- a/lib/form_shui/connection.rb
+++ b/lib/form_shui/connection.rb
@@ -13,7 +13,7 @@ module FormShui
     end
 
     def api_connection
-      @api_connection ||= Faraday.new(url: api_url) do |faraday|
+      @api_connection ||= Faraday.new(url: api_url, ssl: { version: :TLSv1 }) do |faraday|
         faraday.request  :url_encoded             # form-encode POST params
         faraday.request  :auth_hmac               # enables request signing
         faraday.response :raise_error

--- a/spec/form_shui/connection_spec.rb
+++ b/spec/form_shui/connection_spec.rb
@@ -21,12 +21,13 @@ describe FormShui::Connection do
   end
 
   describe "#api_connection" do
+    let(:options){ { url: @obj.api_url, ssl: { version: :TLSv1 } } }
 
     it "should create and cache a faraday connection" do
       conn = double(:connection)
-      Faraday.should_receive(:new).with(url: @obj.api_url).and_return(conn)
+      Faraday.should_receive(:new).with(options).and_return(conn)
       @obj.api_connection.should == conn
-      Faraday.should_not_receive(:new).with(@obj.api_url)
+      Faraday.should_not_receive(:new).with(options)
       @obj.api_connection
     end
 

--- a/spec/form_shui_spec.rb
+++ b/spec/form_shui_spec.rb
@@ -7,7 +7,9 @@ describe FormShui do
     it "should insert faraday logging middleware" do
       FormShui.instance_variable_set("@api_connection", nil)
       conn = double(:connection)
-      Faraday.should_receive(:new).with(url: FormShui.api_url).and_return(conn)
+      Faraday.should_receive(:new)
+        .with(url: FormShui.api_url, ssl: { version: :TLSv1 })
+        .and_return(conn)
       conn.should_receive(:response).with(:logger)
       FormShui.enable_faraday_logger
     end


### PR DESCRIPTION
This is the most basic implementation for forcing the Faraday connection to use TLSv1, ensuring that SSLv3 is not used.

![poodle](http://dl.dropbox.com/u/2094815/Screenshots/mrcv1poglq~f.png) 
